### PR TITLE
Windows are now really maximized and unmaximized.

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -37,6 +37,7 @@ function move(workspace, numberXslots, numberYslots, x, y, xSlotToFill, ySlotToF
             h = arr[3];
         reposition(client, newX, newY, w, h)
     }
+    client.setMaximize(false,false)
 }
 
 function center(workspace) {
@@ -246,7 +247,8 @@ registerShortcut("MoveWindowToRightHeight23_center_biased", "UltrawideWindows: M
 
 // General
 registerShortcut("MoveWindowToMaximize", "UltrawideWindows: Maximize Window", "Meta+Num+0", function () {
-    move(workspace, 1, 1, 0, 0, 1, 1)
+    var client = workspace.activeClient;
+    client.setMaximize(true,true)
 });
 
 registerShortcut("MoveWindowToMaximize1", "UltrawideWindows: Maximize Window (copy)", "alt+Num+0", function () {


### PR DESCRIPTION
I experienced the same issues as expressed in https://github.com/lucmos/UltrawideWindows/issues/20. I fixed it a while before that issue was created but never bothered to make a pull request, but here it is. 

Previously Kwin wasn't made aware that whether a window became maximized or unmaximized, it now is made aware.

It's a relatively easy fix which makes sure Kwin actually knows if a window is maximized or not.