### PR TITLE
Set window unmaximized before moving

### DIFF
--- a/contents/code/main.js
+++ b/contents/code/main.js
@@ -30,6 +30,7 @@ function reposition(client, newX, newY, w, h) {
 function move(workspace, numberXslots, numberYslots, x, y, xSlotToFill, ySlotToFill) {
     var client = workspace.activeClient;
     if (client.moveable) {
+        client.setMaximize(false,false);
         arr = newSlotPosition(workspace, client, numberXslots, numberYslots, x, y, xSlotToFill, ySlotToFill);
         var newX = arr[0],
             newY = arr[1],
@@ -37,7 +38,6 @@ function move(workspace, numberXslots, numberYslots, x, y, xSlotToFill, ySlotToF
             h = arr[3];
         reposition(client, newX, newY, w, h)
     }
-    client.setMaximize(false,false)
 }
 
 function center(workspace) {


### PR DESCRIPTION
Prior this change setting window coords coords for maximized windows did
not work properly.

kwin remebers window geometry of window unmaximized state. If
`setMaximize(false,false)` is called after we set desired geometry kwin
applies remembered unmaximized geometry after we set desired geometry
overriding what we set. Therefore any move command for maximized window
acts like "unmaximize" from an user point of view.

This finally fixes #20