### PR TITLE
Fix qdbus command name on Debian 13

### DIFF
--- a/scripts/common
+++ b/scripts/common
@@ -1,2 +1,13 @@
 package_name="ultrawidewindows"
 package_archive="${package_name}.kwinscript"
+
+# Choose qdbus command. Normally this is 'qdbus', but on Debian 13 it's 'qdbus6'
+QDBUS_CMD="qdbus"
+if [ -r /etc/os-release ]; then
+  . /etc/os-release
+  if [ "${ID}" = "debian" ] && [ "${VERSION_ID}" = "13" ]; then
+    if command -v qdbus6 >/dev/null 2>&1; then
+      QDBUS_CMD="qdbus6"
+    fi
+  fi
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,17 +6,17 @@ cd "$(dirname "${0}")"
 . "$(pwd)/common"
 cd "${cwd}"
 
-isScriptLoaded="$(qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded "${package_name}")"
+isScriptLoaded="$(${QDBUS_CMD} org.kde.KWin /Scripting org.kde.kwin.Scripting.isScriptLoaded "${package_name}")"
 if [ "${isScriptLoaded}" = "true" ]; then
   echo "Unloading ${package_name}"
-  qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "${package_name}" > /dev/null
+  ${QDBUS_CMD} org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript "${package_name}" > /dev/null
 fi
 
 if kpackagetool6 --type KWin/Script --list | grep ${package_name} > /dev/null; then
   kpackagetool6 --type=KWin/Script --remove "${package_name}"
   kwriteconfig6 --file kwinrc --group Plugins --key "${package_name}Enabled" --delete
   # Cleanup the shortcuts after having them removed
-  qdbus org.kde.kglobalaccel /component/kwin org.kde.kglobalaccel.Component.cleanUp > /dev/null
+  ${QDBUS_CMD} org.kde.kglobalaccel /component/kwin org.kde.kglobalaccel.Component.cleanUp > /dev/null
   # Reload the configuration
   dbus-send --type=signal --dest=org.kde.KWin /KWin org.kde.KWin.reloadConfig
   # Wait for the config to be reloaded - required, otherwise the update.sh script

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -16,7 +16,7 @@ dbus-send --type=signal --dest=org.kde.KWin /KWin org.kde.KWin.reloadConfig
 # command below doesn't work and the script doesn't activate.
 # Seems like 1 sec sleep is enough
 sleep 1
-loaded=$(qdbus org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "${package_name}")
+loaded=$(${QDBUS_CMD} org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript "${package_name}")
 if [ "${loaded}" -ne 1 ]; then
   echo >&2 "Failed to load ${package_name}. Try to logout and login again"
   exit 1
@@ -24,4 +24,4 @@ fi
 
 # Reload the configuration and make the shortcuts appear in the kglobalshortcutsrc
 # without having to logout and log back in
-qdbus org.kde.kglobalaccel /component/kwin org.kde.kglobalaccel.Component.cleanUp > /dev/null
+${QDBUS_CMD} org.kde.kglobalaccel /component/kwin org.kde.kglobalaccel.Component.cleanUp > /dev/null


### PR DESCRIPTION
This fixes #47, correctly using `qdbus6` instead of `qdbus` when Debian 13 is detected.
